### PR TITLE
Use command -v instead of which

### DIFF
--- a/bash/.bash_greeter
+++ b/bash/.bash_greeter
@@ -110,7 +110,7 @@ __print_greeting ()
 {
     local STR_GREETING="-= welcome =-"
 
-    if [[ $(which figlet) ]]; then
+    if [[ $(command -v figlet) ]]; then
         #Print hostename with figlets
         __print_ascii_art "$STR_GREETING"
     else

--- a/bash/.bashrc.d/pyenv
+++ b/bash/.bashrc.d/pyenv
@@ -11,7 +11,7 @@ export PKG_CONFIG_PATH="/usr/local/opt/python@3.8/lib/pkgconfig"
 
 # pyenv setup
 eval "$(pyenv init -)"
-if which pyenv-virtualenv-init > /dev/null; then eval "$(pyenv virtualenv-init -)"; fi
+if command -v pyenv-virtualenv-init > /dev/null; then eval "$(pyenv virtualenv-init -)"; fi
 
 # Pyenv-virtualenvwrapper
 export PYENV_VIRTUALENVWRAPPER_PREFER_PYVENV="true"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -161,5 +161,5 @@ source ~/.bash_greeter
 # export PATH="$HOME/.bin:$PATH"
 # export NVM_DIR="$HOME/.nvm"
 # [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
-# if which pyenv > /dev/null; then eval "$(pyenv init -)"; fi
-# if which pyenv-virtualenv-init > /dev/null; then eval "$(pyenv virtualenv-init -)"; fi
+# if command -v pyenv > /dev/null; then eval "$(pyenv init -)"; fi
+# if command -v pyenv-virtualenv-init > /dev/null; then eval "$(pyenv virtualenv-init -)"; fi

--- a/zsh/.zshrc.d/pyenv
+++ b/zsh/.zshrc.d/pyenv
@@ -10,8 +10,8 @@ export LDFLAGS="-L/usr/local/opt/python@3.8/lib"
 export PKG_CONFIG_PATH="/usr/local/opt/python@3.8/lib/pkgconfig"
 
 # pyenv setup
-if which pyenv > /dev/null; then eval "$(pyenv init -)"; fi
-if which pyenv-virtualenv-init > /dev/null; then eval "$(pyenv virtualenv-init -)"; fi
+if command -v pyenv > /dev/null; then eval "$(pyenv init -)"; fi
+if command -v pyenv-virtualenv-init > /dev/null; then eval "$(pyenv virtualenv-init -)"; fi
 
 # yyenv-virtualenvwrapper
 export PYENV_VIRTUALENVWRAPPER_PREFER_PYVENV="true"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR replaces usage of the `which` command with the builtin `command -v`.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

In addition to causing `bash` scripts to fail the `shell-lint` `pre-commit` hook as seen [in this GH Actions run](https://github.com/cisagov/.dotfiles/runs/1914387757), it is generally preferred to use `command -v` over `which` when writing scripts. Although `which` is a builtin in `zsh`, I think it's better to use a standard whenever possible for consistency.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
 Automated checks pass and there should be no issues with the replacement with how `which` was being used in these files.
<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
